### PR TITLE
Remove player-container overflow #121

### DIFF
--- a/public/stylesheets/videojs-playlist-ui-demo.css
+++ b/public/stylesheets/videojs-playlist-ui-demo.css
@@ -13,6 +13,7 @@ body {
 .player-container {
   background: #1a1a1a;
   overflow: auto;
+  overflow-y: hidden;
   /*width: 900px;*/
   width: 100%;
   margin-left: 0;


### PR DESCRIPTION
Hide overflow on the player-container div to remove extra scroll bar caused by small size difference.