### PR TITLE
Hide decorative icons from screen readers

### DIFF
--- a/templates/home.mustache
+++ b/templates/home.mustache
@@ -79,7 +79,7 @@
       <div class="column-one">
 
         <!--<div class="circle-one"></div>-->
-        <p><i class="fas fa-question-circle"></i><p>
+        <p><i class="fas fa-question-circle" aria-hidden="true"></i><p>
         <p>Our mission is to provide text-searchable lecture videos for all students</p>
 
       </div>
@@ -87,7 +87,7 @@
       <div class="column-two">
 
         <!--<div class="circle-two"></div>-->
-        <p><i class="fas fa-comments"></i><p>
+        <p><i class="fas fa-comments" aria-hidden="true"></i><p>
         <p>Captions are created using automated transcription and perfected with your help</p>
 
       </div>
@@ -96,7 +96,7 @@
       <div class="column-three">
 
         <!--<div class="circle-three"></div>-->
-        <p><i class="fas fa-universal-access"></i></p>
+        <p><i class="fas fa-universal-access" aria-hidden="true"></i></p>
           <p>We strive to meet modern accessibility standards to promote inclusive learning</p>
 
     </div>
@@ -153,7 +153,7 @@
           <div class="contact-text">
 
             Questions? Comments? Let us know!
-            <i class="fas fa-envelope"></i> <a href="mailto:classtranscribe@illinois.edu">ClassTranscribe@illinois.edu</a>
+            <i class="fas fa-envelope" aria-hidden="true"></i> <a href="mailto:classtranscribe@illinois.edu">ClassTranscribe@illinois.edu</a>
 
           </div>
 


### PR DESCRIPTION
Some screen readers announce the underlying ASCII char for icon fonts, so the icons should either be labeled or hidden. In this case the icons are purely decorative, so we'll use `aria-hidden="true"`.